### PR TITLE
Fix bbox z precision

### DIFF
--- a/src/napari_bbox/boundingbox/napari_0_4_15/bounding_box.py
+++ b/src/napari_bbox/boundingbox/napari_0_4_15/bounding_box.py
@@ -178,12 +178,12 @@ class BoundingBox(ABC):
         
     def _update_slice_key(self):
         data_not_displayed = self.data[:, self.dims_not_displayed]
-        self.slice_key = np.round(
+        self.slice_key = np.array(
             [
                 np.min(data_not_displayed, axis=0),
                 np.max(data_not_displayed, axis=0),
             ]
-        ).astype('int')        
+        )       
 
     @property
     def ndisplay(self):


### PR DESCRIPTION
If z scale factors are used, bounding boxes do not display at the correct z depth. Fixes #18.

Changes:
- bounding box slice key can be kept as a float to deal with z scaling factors.