### PR TITLE
PyQt6 compatibility for combobox activated signal 

### DIFF
--- a/src/napari_bbox/boundingbox/napari_0_4_15/qt_bounding_box_control.py
+++ b/src/napari_bbox/boundingbox/napari_0_4_15/qt_bounding_box_control.py
@@ -211,7 +211,7 @@ class QtBoundingBoxControls(QtLayerControls):
         bb_size_mode_combobox = QComboBox()
         bb_size_mode_combobox.addItem("average")
         bb_size_mode_combobox.addItem("constant")
-        bb_size_mode_combobox.activated[str].connect(self.changeSizeMode)
+        bb_size_mode_combobox.activated.connect(self.changeSizeMode)
         self.bb_size_mode_combobox = bb_size_mode_combobox
 
         bb_size_mult_slider = QLabeledDoubleSlider(Qt.Horizontal, parent=self)
@@ -401,7 +401,8 @@ class QtBoundingBoxControls(QtLayerControls):
         self.layer.text.size = float(value) / 2
 
     def changeSizeMode(self, value=None):
-        self.layer.size_mode = value
+        mode = self.bb_size_mode_combobox.itemText(value)
+        self.layer.size_mode = mode
 
     def changeSizeMultiplier(self, value):
         self.layer.size_multiplier = value

--- a/src/napari_bbox/boundingbox/napari_0_4_18/qt_bounding_box_control.py
+++ b/src/napari_bbox/boundingbox/napari_0_4_18/qt_bounding_box_control.py
@@ -212,7 +212,7 @@ class QtBoundingBoxControls(QtBoundingBoxControls):
         bb_size_mode_combobox = QComboBox()
         bb_size_mode_combobox.addItem("average")
         bb_size_mode_combobox.addItem("constant")
-        bb_size_mode_combobox.activated[str].connect(self.changeSizeMode)
+        bb_size_mode_combobox.activated.connect(self.changeSizeMode)
         self.bb_size_mode_combobox = bb_size_mode_combobox
 
         bb_size_mult_slider = QLabeledDoubleSlider(Qt.Horizontal, parent=self)


### PR DESCRIPTION
Closes : https://github.com/bauerdavid/napari-bbox/issues/20

I got a bit of help from copilot in explaining this.
PyQt6 has dropped the dict for the activated signal. So activated[str] returns a key error.
But if we use `activated` without the [str] then the signal has the `int` value, so the index of the item.
So in the callback I just get the string of the mode using the index. Then it's handled by the Enum properly.
This way there are not QT version checks needed.

As far as I can tell, the mode is set correctly. I am not sure what the difference between average and constant should be, so other than checking `layer.size_mode` I can't really test?
